### PR TITLE
Fix lockscreen volume mirroring for remote/group players

### DIFF
--- a/docs/PR_VOLUME_MIRRORING_FIX.md
+++ b/docs/PR_VOLUME_MIRRORING_FIX.md
@@ -1,0 +1,48 @@
+# PR: Fix lockscreen volume mirroring for remote/group players
+
+## Summary
+
+Fixes the volume jump bug in lockscreen hardware volume control when using remote/group players. The system volume slider now shadows the MA player volume without dangerous jumps or desync.
+
+**References:**
+- Original feature: `ea7144d` (Sync group volume management, hardware volume buttons)
+- Original feature introduced unintended behaviour and was pathed: `688b635` (Fix hardware volume in background)
+
+## Problem
+
+When the app was backgrounded and the system volume changed (e.g., for YouTube), returning to use hardware buttons for MA volume control caused potentially very large volume jumps — the system volume (e.g., 100%) was mirrored directly to MA, potentially blowing out speakers and killing the cat. The patch in `688b635` stopped the volume observer on pause, but this disabled lockscreen volume control entirely.
+
+## Approach
+
+Instead of mirroring system volume values to MA, hardware buttons are now treated as **directional step inputs**. The system volume slider becomes a "button press detector" that silently resets after each event, while MA volume changes independently in safe increments.
+
+## Changes
+
+### `MainActivity.kt` (Kotlin — native layer)
+- **`isMAPlaying` guard**: Observer suppresses mirroring when MA is not actively streaming (`isMusicActive`, `MODE_NORMAL` checks), replacing the stop/start of `688b635`
+- **Observer stays alive across pause/resume**: `onPause` only disables `dispatchKeyEvent` (foreground key interception); the observer remains active for lockscreen button detection
+- **Direction + delta signal**: Each observer event sends `direction` (+1/-1) and `delta` (per-step size mapped to 0-100) to Flutter
+- **Center-reset with MA shadow**: After each event, system volume resets to the position matching `estimatedMAVolume`, clamped to `[1, max-1]` so buttons always have room in both directions. The slider visually tracks MA instead of snapping to midpoint
+- **Reduced ignore window**: `ignoringVolumeChange` guard reduced from 1000ms to 100ms, preventing button presses from being swallowed
+
+### `lib/main.dart` (Flutter — app layer)
+- **Always-step mode**: `_setAbsoluteVolume` never mirrors the system value directly — steps MA by the native `delta` in the button `direction`, making volume jumps structurally impossible
+- **`_lastSteppedVolume` tracking**: Accumulates volume changes synchronously so rapid presses (hold button) use the correct base instead of stale `player.volume`
+- **Play-resume re-sync**: When `isPlaying` transitions true, syncs system volume to MA, closing any drift from the suppression window
+- **`setMAPlayingState`**: Sends playback state to native layer so the observer can self-guard
+
+### `lib/services/hardware_volume_service.dart`
+- Updated `onAbsoluteVolumeChange` stream type to include `direction` and `delta` fields
+- Added `setMAPlayingState()` method to notify native layer of playback state
+
+## How it works
+
+1. User presses hardware volume button on lockscreen
+2. System volume changes by 1 step → ContentObserver fires
+3. Kotlin detects direction and delta, sends to Flutter, resets system to MA-equivalent position (clamped [1, max-1])
+4. Flutter steps MA by delta in that direction, tracks accumulated value
+5. System slider visually shadows MA position; buttons always work in both directions
+
+**Desync scenario** (MA=20%, system was changed to 100% while paused):
+- Play resumes → system syncs back to 20%
+- If sync didn't happen: button press steps MA by ~7%, never jumps to 100%

--- a/logs2.txt
+++ b/logs2.txt
@@ -1,0 +1,6 @@
+No supported devices found with name or id matching 'Medium_Phone_API_36.1'.
+
+The following devices were found:
+Windows (desktop) ΓÇó windows ΓÇó windows-x64    ΓÇó Microsoft Windows [Version 10.0.26200.7840]
+Chrome (web)      ΓÇó chrome  ΓÇó web-javascript ΓÇó Google Chrome 145.0.7632.77
+Edge (web)        ΓÇó edge    ΓÇó web-javascript ΓÇó Microsoft Edge 145.0.3800.70

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -625,18 +625,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_design_icons_flutter:
     dependency: "direct main"
     description:
@@ -1086,10 +1086,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Hi,
I love your app! You've done an awesome job.
Regards, Peter

# PR: Fix lockscreen volume mirroring for remote/group players

## Summary

Fixes the volume jump bug in lockscreen hardware volume control when using remote/group players. The system volume slider now shadows the MA player volume without dangerous jumps or desync.

**References:**
- Original feature: `ea7144d` (Sync group volume management, hardware volume buttons)
- Original feature introduced unintended behaviour and was pathed: `688b635` (Fix hardware volume in background)

## Problem

When the app was backgrounded and the system volume changed (e.g., for YouTube), returning to use hardware buttons for MA volume control caused potentially very large volume jumps — the system volume (e.g., 100%) was mirrored directly to MA, potentially blowing out speakers and killing the cat. The patch in `688b635` stopped the volume observer on pause, but this disabled lockscreen volume control entirely.

## Approach

Instead of mirroring system volume values to MA, hardware buttons are now treated as **directional step inputs**. The system volume slider becomes a "button press detector" that silently resets after each event, while MA volume changes independently in safe increments.

## Changes

### `MainActivity.kt` (Kotlin — native layer)
- **`isMAPlaying` guard**: Observer suppresses mirroring when MA is not actively streaming (`isMusicActive`, `MODE_NORMAL` checks), replacing the stop/start of `688b635`
- **Observer stays alive across pause/resume**: `onPause` only disables `dispatchKeyEvent` (foreground key interception); the observer remains active for lockscreen button detection
- **Direction + delta signal**: Each observer event sends `direction` (+1/-1) and `delta` (per-step size mapped to 0-100) to Flutter
- **Center-reset with MA shadow**: After each event, system volume resets to the position matching `estimatedMAVolume`, clamped to `[1, max-1]` so buttons always have room in both directions. The slider visually tracks MA instead of snapping to midpoint
- **Reduced ignore window**: `ignoringVolumeChange` guard reduced from 1000ms to 100ms, preventing button presses from being swallowed

### `lib/main.dart` (Flutter — app layer)
- **Always-step mode**: `_setAbsoluteVolume` never mirrors the system value directly — steps MA by the native `delta` in the button `direction`, making volume jumps structurally impossible
- **`_lastSteppedVolume` tracking**: Accumulates volume changes synchronously so rapid presses (hold button) use the correct base instead of stale `player.volume`
- **Play-resume re-sync**: When `isPlaying` transitions true, syncs system volume to MA, closing any drift from the suppression window
- **`setMAPlayingState`**: Sends playback state to native layer so the observer can self-guard

### `lib/services/hardware_volume_service.dart`
- Updated `onAbsoluteVolumeChange` stream type to include `direction` and `delta` fields
- Added `setMAPlayingState()` method to notify native layer of playback state

## How it works

1. User presses hardware volume button on lockscreen
2. System volume changes by 1 step → ContentObserver fires
3. Kotlin detects direction and delta, sends to Flutter, resets system to MA-equivalent position (clamped [1, max-1])
4. Flutter steps MA by delta in that direction, tracks accumulated value
5. System slider visually shadows MA position; buttons always work in both directions

**Desync scenario** (MA=20%, system was changed to 100% while paused):
- Play resumes → system syncs back to 20%
- If sync didn't happen: button press steps MA by ~7%, never jumps to 100%
